### PR TITLE
Remove unnecessary constraints

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,11 @@
+network-manager-l2tp (1.20.2-2) UNRELEASED; urgency=medium
+
+  * Remove constraints unnecessary since buster:
+    + Build-Depends: Drop versioned constraint on libglib2.0-dev, libgtk-3-dev,
+      libnma-dev, libsecret-1-dev and ppp-dev.
+
+ -- Debian Janitor <janitor@jelmer.uk>  Wed, 20 Apr 2022 01:31:34 -0000
+
 network-manager-l2tp (1.20.2-1) unstable; urgency=medium
 
   * New upstream release

--- a/debian/control
+++ b/debian/control
@@ -4,13 +4,13 @@ Priority: optional
 Maintainer: Douglas Kosovic <doug@uq.edu.au>
 Build-Depends: debhelper-compat (= 13),
                libnm-dev (>= 1.20.0),
-               libnma-dev (>= 1.8.0),
+               libnma-dev,
                libnma-gtk4-dev (>= 1.8.33),
-               ppp-dev (>= 2.4.7-1+1),
-               libsecret-1-dev (>= 0.18),
-               libgtk-3-dev (>= 3.16),
+               ppp-dev,
+               libsecret-1-dev,
+               libgtk-3-dev,
                libgtk-4-dev (>= 4.0),
-               libglib2.0-dev (>= 2.34),
+               libglib2.0-dev,
                libgtk-4-bin (>= 4.6.2),
                libnss3-dev,
                libssl-dev


### PR DESCRIPTION

Remove unnecessary constraints.


This merge proposal was created automatically by the [Janitor bot](https://janitor.debian.net/scrub-obsolete).
For more information, including instructions on how to disable
these merge proposals, see https://janitor.debian.net/scrub-obsolete.

You can follow up to this merge proposal as you normally would.

The bot will automatically update the merge proposal to resolve merge conflicts
or close the merge proposal when all changes are applied through other means
(e.g. cherry-picks). Updates may take several hours to propagate.

Build and test logs for this branch can be found at
https://janitor.debian.net/scrub-obsolete/pkg/network-manager-l2tp/7d9e6a54-fa7b-467f-aa3d-e855692b4807.



## Debdiff

These changes affect the binary packages:


File lists identical (after any substitutions)

No differences were encountered between the control files of package \*\*network-manager-l2tp\*\*

No differences were encountered between the control files of package \*\*network-manager-l2tp-dbgsym\*\*
### Control files of package network-manager-l2tp-gnome: lines which differ (wdiff format)
* Depends: libc6 (>= 2.14), libglib2.0-0 (>= 2.37.3), libgtk-3-0 (>= [-3.16),-] {+3.3.16),+} libgtk-4-1 (>= 4.0.0), libnm0 (>= 1.20.0), libnma-gtk4-0 (>= 1.8.34), libnma0 (>= 1.8.0), libsecret-1-0 (>= [-0.18),-] {+0.7),+} libssl1.1 (>= 1.1.0), network-manager-l2tp (= 

No differences were encountered between the control files of package \*\*network-manager-l2tp-gnome-dbgsym\*\*


You can also view the [diffoscope diff](https://janitor.debian.net/api/run/7d9e6a54-fa7b-467f-aa3d-e855692b4807/diffoscope?filter_boring=1) ([unfiltered](https://janitor.debian.net/api/run/7d9e6a54-fa7b-467f-aa3d-e855692b4807/diffoscope)).
